### PR TITLE
Fix(CBOM examples): Fixed bom-refs

### DIFF
--- a/CBOM/Protocol/bom.json
+++ b/CBOM/Protocol/bom.json
@@ -27,7 +27,7 @@
               "algorithms": [
                 "crypto/algorithm/ecdh-curve25519@1.3.132.1.12",
                 "crypto/algorithm/rsa-2048@1.2.840.113549.1.1.1",
-                "crypto/algorithm/aes-128-gcm@2.16.840.1.101.3.4.1.6",
+                "crypto/algorithm/aes-256-gcm@2.16.840.1.101.3.4.1.46",
                 "crypto/algorithm/sha-384@2.16.840.1.101.3.4.2.9"
               ],
               "identifiers": [ "0xC0", "0x30" ]
@@ -51,8 +51,8 @@
           "issuerName": "C = US, O = Google Trust Services LLC, CN = GTS CA 1C3",
           "notValidBefore": "2016-11-21T08:00:00Z",
           "notValidAfter": "2017-11-22T07:59:59Z",
-          "signatureAlgorithmRef": "crypto/algorithm/sha512-rsa@1.2.840.113549.1.1.13",
-          "subjectPublicKeyRef": "crypto/key/rsa2048@1.2.840.113549.1.1.1",
+          "signatureAlgorithmRef": "crypto/algorithm/sha-512-rsa@1.2.840.113549.1.1.13",
+          "subjectPublicKeyRef": "crypto/key/rsa-2048@1.2.840.113549.1.1.1",
           "certificateFormat": "X.509",
           "certificateExtension": "crt"
         }
@@ -89,7 +89,7 @@
           "algorithmRef": "crypto/algorithm/rsa-2048@1.2.840.113549.1.1.1",
           "securedBy": {
             "mechanism": "Software",
-            "algorithmRef": "crypto/algorithm/aes-128-gcm@2.16.840.1.101.3.4.1.6"
+            "algorithmRef": "crypto/algorithm/aes-256-gcm@2.16.840.1.101.3.4.1.46"
           },
           "creationDate": "2016-11-21T08:00:00Z",
           "activationDate": "2016-11-21T08:20:00Z"
@@ -143,7 +143,7 @@
           "implementationPlatform": "x86_64",
           "certificationLevel": [ "none" ],
           "cryptoFunctions": [ "encrypt", "decrypt" ],
-          "classicalSecurityLevel": 128,
+          "classicalSecurityLevel": 256,
           "nistQuantumSecurityLevel": 1
         },
         "oid": "2.16.840.1.101.3.4.1.46"


### PR DESCRIPTION
- Some bom-refs in this example were not correct or had typos so that they could not be referred to in this CBOM
- There were also some references to AES-128 although it is not used in TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

I hope I did not miss anything but feel free to criticize and add to my changes.