### PR TITLE
fix: add `some-library` and `aes128gcm` as dependency

### DIFF
--- a/CBOM/Example-With-Dependencies/bom.json
+++ b/CBOM/Example-With-Dependencies/bom.json
@@ -54,6 +54,12 @@
       "ref": "crypto-library",
       "provides": ["aes128gcm"],
       "dependsOn": ["some-library"]
+    },
+    {
+      "ref": "some-library"
+    },
+    {
+      "ref": "aes128gcm"
     }
   ]
 }


### PR DESCRIPTION
Fixes #47 