### PR TITLE
docs: add ML-BOM model card example

### DIFF
--- a/MLBOM/Model-Card-With-Dataset/README.md
+++ b/MLBOM/Model-Card-With-Dataset/README.md
@@ -1,0 +1,16 @@
+# Model Card With Dataset References
+
+This example shows a compact ML-BOM for an application that uses one fictional
+machine-learning model and two fictional datasets.
+
+The BOM demonstrates:
+
+- a `machine-learning-model` component with an inline `modelCard`
+- `modelCard.modelParameters.datasets[]` entries that reference dataset
+  components by `bom-ref`
+- `data` components that include the recommended `data` property
+- top-level dependency links from the model to the referenced datasets
+
+All names, URLs, and metric values are illustrative. They are not statements
+about a real model, dataset, performance result, license, safety posture, or
+deployment.

--- a/MLBOM/Model-Card-With-Dataset/bom.json
+++ b/MLBOM/Model-Card-With-Dataset/bom.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "serialNumber": "urn:uuid:df4f6ec7-6d36-47e6-a15b-640a0af54267",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-04-28T12:00:00Z",
+    "component": {
+      "type": "application",
+      "bom-ref": "component-support-triage-service",
+      "name": "support-triage-service",
+      "version": "1.0.0",
+      "description": "Fictional application that uses a text classification model to route support tickets."
+    }
+  },
+  "components": [
+    {
+      "type": "machine-learning-model",
+      "bom-ref": "component-support-ticket-classifier",
+      "publisher": "Example ML Team",
+      "name": "support-ticket-classifier",
+      "version": "1.0.0",
+      "description": "Fictional supervised text classification model for support ticket routing.",
+      "modelCard": {
+        "bom-ref": "model-card-support-ticket-classifier",
+        "modelParameters": {
+          "approach": {
+            "type": "supervised"
+          },
+          "task": "text-classification",
+          "architectureFamily": "transformer",
+          "modelArchitecture": "encoder-only transformer",
+          "datasets": [
+            {
+              "ref": "component-support-ticket-training-data"
+            },
+            {
+              "ref": "component-support-ticket-evaluation-data"
+            }
+          ],
+          "inputs": [
+            {
+              "format": "text/plain"
+            }
+          ],
+          "outputs": [
+            {
+              "format": "application/json"
+            }
+          ]
+        },
+        "quantitativeAnalysis": {
+          "performanceMetrics": [
+            {
+              "type": "macro-f1",
+              "value": "0.91",
+              "slice": "held-out-evaluation"
+            }
+          ]
+        },
+        "considerations": {
+          "users": [
+            "Support operations staff reviewing suggested ticket queues."
+          ],
+          "useCases": [
+            "Suggest an initial support queue for a newly received support ticket."
+          ],
+          "technicalLimitations": [
+            "The example model is illustrative and should not be used to infer production readiness."
+          ],
+          "performanceTradeoffs": [
+            "The illustrative metric is included only to demonstrate the CycloneDX modelCard structure."
+          ],
+          "ethicalConsiderations": [
+            {
+              "name": "automation bias",
+              "mitigationStrategy": "Human review remains responsible for final ticket routing."
+            }
+          ],
+          "fairnessAssessments": [
+            {
+              "groupAtRisk": "Customers using underrepresented languages or dialects",
+              "benefits": "Faster initial triage when the model is reliable for the submitted language.",
+              "harms": "Misrouting can delay support if the model performs poorly for the submitted language.",
+              "mitigationStrategy": "Monitor routing quality across language slices and allow manual override."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "data",
+      "bom-ref": "component-support-ticket-training-data",
+      "name": "support-ticket-training-data",
+      "version": "2026.04",
+      "description": "Fictional dataset component used to train the support ticket classifier.",
+      "data": [
+        {
+          "bom-ref": "data-support-ticket-training-data",
+          "type": "dataset",
+          "name": "Support Ticket Training Data",
+          "contents": {
+            "url": "https://example.com/datasets/support-tickets/train.jsonl"
+          },
+          "classification": "internal",
+          "description": "Illustrative training split for the fictional support ticket classifier."
+        }
+      ]
+    },
+    {
+      "type": "data",
+      "bom-ref": "component-support-ticket-evaluation-data",
+      "name": "support-ticket-evaluation-data",
+      "version": "2026.04",
+      "description": "Fictional held-out dataset component used to evaluate the support ticket classifier.",
+      "data": [
+        {
+          "bom-ref": "data-support-ticket-evaluation-data",
+          "type": "dataset",
+          "name": "Support Ticket Evaluation Data",
+          "contents": {
+            "url": "https://example.com/datasets/support-tickets/eval.jsonl"
+          },
+          "classification": "internal",
+          "description": "Illustrative evaluation split for the fictional support ticket classifier."
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "component-support-triage-service",
+      "dependsOn": [
+        "component-support-ticket-classifier"
+      ]
+    },
+    {
+      "ref": "component-support-ticket-classifier",
+      "dependsOn": [
+        "component-support-ticket-training-data",
+        "component-support-ticket-evaluation-data"
+      ]
+    },
+    {
+      "ref": "component-support-ticket-training-data"
+    },
+    {
+      "ref": "component-support-ticket-evaluation-data"
+    }
+  ]
+}

--- a/MLBOM/README.md
+++ b/MLBOM/README.md
@@ -1,0 +1,13 @@
+# Machine Learning Bill of Materials (ML-BOM)
+
+A Machine Learning Bill of Materials (ML-BOM) describes AI/ML inventory such as
+models, datasets, and related artifacts. CycloneDX supports ML-BOM use cases with
+component types such as `machine-learning-model` and `data`, plus `modelCard`
+metadata for model transparency.
+
+This directory contains compact examples that are intended to be easy to inspect,
+validate, and reuse as starting points.
+
+| Example | Description |
+|---------|-------------|
+| [Model Card With Dataset References](Model-Card-With-Dataset) | A schema-valid ML-BOM showing one application, one model component, two dataset components, an inline model card, dataset references, and dependency links. |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ are categorized by different BOM types including:
 |--------------------|-----------------------------------------|
 | [CBOM](CBOM)       | Cryptography Bill of Materials          |
 | [HBOM](HBOM)       | Hardware Bill of Materials              |
+| [MLBOM](MLBOM)     | Machine Learning Bill of Materials      |
 | [OBOM](OBOM)       | Operations Bill of Materials            |
 | [SaaSBOM](SaaSBOM) | Software-as-a-Service Bill of Materials |
 | [SBOM](SBOM)       | Software Bill of Materials              |


### PR DESCRIPTION
What changed

Adds a compact ML-BOM example to the official BOM examples collection.

The example shows one fictional application, one `machine-learning-model` component, two `data` components, an inline `modelCard`, dataset references from `modelCard.modelParameters.datasets[]`, and top-level dependency links from the model to the dataset components.

Why

CycloneDX already supports ML-BOM use cases in the specification, but this examples repo does not currently have an ML-BOM family directory. A small schema-valid example can give implementers a copyable starting point without requiring them to read the full schema first.

Related: #50 explored a broader ML-BOM example set. This PR is intentionally narrower and focuses on one schema-valid model-card/dataset-reference path.

Boundary

The model, datasets, URLs, and metric values are fictional. They are included only to demonstrate CycloneDX structure, not to make claims about a real model, dataset, performance result, license, safety posture, or deployment.

Validation

Ran locally:

jq . MLBOM/Model-Card-With-Dataset/bom.json

git diff --check

python3 local markdown-link check for README links

npx --yes ajv-cli@5.0.0 validate \
  -s /tmp/cyclonedx-specification/schema/bom-1.7.schema.json \
  -r /tmp/cyclonedx-specification/schema/spdx.schema.json \
  -r /tmp/cyclonedx-specification/schema/jsf-0.82.schema.json \
  -r /tmp/cyclonedx-specification/schema/cryptography-defs.schema.json \
  -d MLBOM/Model-Card-With-Dataset/bom.json \
  --strict=false

The AJV run reports the expected unknown-format warnings for schema formats not loaded by ajv-cli, then validates the BOM as valid.
